### PR TITLE
No included phpcs standards, and allowed extra Joomla folder in coding standards repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@ Performs included code tests
 * **setCodeStyleStandardsBranch($codeStyleStandardsBranch):**  Branch of the coding standards repository to use.  Default: *master* 
 * **setCodeStyleCheckFolders($codeStyleCheckFolders):**  Folders to perform the code style check in. 
 * **setCodeStyleExcludedPaths($codeStyleExcludedPaths):** Array of paths (files/folders/path patterns) to exclude from the code style checking. 
+* **setCodeStyleExtraJoomlaFolder($codeStyleExtraJoomlaFolder):** Include an extra Joomla folder for checking code style (set to false if the cs repository uses a Joomla folder for the standards).
 
 #### Functions
 

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,6 @@
     "php"                             : ">=5.4.0",
     "consolidation/robo"              : "~1",
     "squizlabs/php_codesniffer"       : "~2",
-    "greencape/coding-standards"      : "~1",
     "cloudinary/cloudinary_php"       : "~1",
     "knplabs/github-api"              : "~1",
     "joomla-projects/joomla-testing"  : "dev-container-test"

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "0842566c5e763ad1cc2ea15008ab8c57",
-    "content-hash": "303a5ab9b47bfa5dd89fcc7682ee1e78",
+    "hash": "16245c115a210e7785b9b9e488e45067",
+    "content-hash": "4579920dafd21571c1f8c255b48e528c",
     "packages": [
         {
             "name": "cloudinary/cloudinary_php",
@@ -310,51 +310,6 @@
             ],
             "description": "Promoting the interoperability of container objects (DIC, SL, etc.)",
             "time": "2014-12-30 15:22:37"
-        },
-        {
-            "name": "greencape/coding-standards",
-            "version": "1.0.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/GreenCape/coding-standards.git",
-                "reference": "2606fb6ec52402972aec99665ab47a7a3b5eb896"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/GreenCape/coding-standards/zipball/2606fb6ec52402972aec99665ab47a7a3b5eb896",
-                "reference": "2606fb6ec52402972aec99665ab47a7a3b5eb896",
-                "shasum": ""
-            },
-            "require": {
-                "squizlabs/php_codesniffer": "~2"
-            },
-            "replace": {
-                "greencape/joomla-cs": "*"
-            },
-            "require-dev": {
-                "codegyre/robo": "^0.6.0",
-                "phpunit/phpunit": "~4.0"
-            },
-            "type": "library",
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Niels Braczek",
-                    "email": "nbraczek@bsds.de",
-                    "role": "lead"
-                }
-            ],
-            "description": "Composer installable Coding Standards Definitions.",
-            "homepage": "https://github.com/GreenCape/coding-standards",
-            "keywords": [
-                "joomla",
-                "phpcs",
-                "standards"
-            ],
-            "time": "2015-11-14 02:57:58"
         },
         {
             "name": "guzzle/guzzle",

--- a/src/Tasks/CodeChecks.php
+++ b/src/Tasks/CodeChecks.php
@@ -114,11 +114,20 @@ final class CodeChecks extends GenericTask
 	private $codeStyleExcludedPaths = array();
 
 	/**
+	 * Include an extra Joomla folder for checking code style (set to false if the cs repository uses a Joomla folder for the standards)
+	 *
+	 * @var     boolean
+	 *
+	 * @since   1.0.0
+	 */
+	private $codeStyleExtraJoomlaFolder = true;
+
+	/**
 	 * Set the path of the repository
 	 *
 	 * @param   string  $baseRepositoryPath  Base path of the repository
 	 *
-	 * @return $this
+	 * @return  $this
 	 *
 	 * @since   1.0.0
 	 */
@@ -237,6 +246,8 @@ final class CodeChecks extends GenericTask
 	public function setCodeStyleCheckFolders($codeStyleCheckFolders)
 	{
 		$this->codeStyleCheckFolders = $codeStyleCheckFolders;
+
+		return $this;
 	}
 
 	/**
@@ -251,6 +262,24 @@ final class CodeChecks extends GenericTask
 	public function setCodeStyleExcludedPaths($codeStyleExcludedPaths)
 	{
 		$this->codeStyleExcludedPaths = $codeStyleExcludedPaths;
+
+		return $this;
+	}
+
+	/**
+	 * Include an extra Joomla folder for checking code style (set to false if the cs repository uses a Joomla folder for the standards)
+	 *
+	 * @param   boolean  $codeStyleExtraJoomlaFolder  Set the folder flag on/off
+	 *
+	 * @return  $this
+	 *
+	 * @since   1.0.0
+	 */
+	public function setCodeStyleExtraJoomlaFolder($codeStyleExtraJoomlaFolder)
+	{
+		$this->codeStyleExtraJoomlaFolder = $codeStyleExtraJoomlaFolder;
+
+		return $this;
 	}
 
 	/**
@@ -480,7 +509,8 @@ final class CodeChecks extends GenericTask
 
 			$command = 'git' . $this->getGitExecutableExtension() .
 				' clone -b ' . $this->codeStyleStandardsBranch . ' --single-branch --depth 1 ' .
-				'https://github.com/' . $this->codeStyleStandardsRepo . '.git ' . $this->codeStyleStandardsFolder . '/Joomla';
+				'https://github.com/' . $this->codeStyleStandardsRepo . '.git ' . $this->codeStyleStandardsFolder .
+				($this->codeStyleExtraJoomlaFolder ? '/Joomla' : '');
 
 			if (!$roboHandler->executeCommand($command))
 			{


### PR DESCRIPTION
phptodude new branch will be allowed now by setting the new flag to false.

Example with this repository:

```
		$sniffersPath = __DIR__ . '/.tmp/coding-standards';

		$this->taskCodeChecks()
			->setBaseRepositoryPath(JPATH_TESTING_BASE)
			->setCodeStyleStandardsRepo('photodude/coding-standards')
			->setCodeStyleStandardsBranch('phpcs-2')
			->setCodeStyleExtraJoomlaFolder(false)
			->setCodeStyleStandardsFolder($sniffersPath)
			->setCodeStyleCheckFolders(['src'])
			->checkCodeStyle()
			->run();
```
