### PR TITLE
Container test

### DIFF
--- a/src/RoboFile/ClientContainer.php
+++ b/src/RoboFile/ClientContainer.php
@@ -64,29 +64,19 @@ trait ClientContainer
 		$opts = array(
 			'env' => 'desktop',
 			'debug' => false,
-			'single' => false,
 			'suite' => 'acceptance',
 			'test' => 'install',
-			'server' => 'php'
+			'server' => 'php',
+			'config' => ''
 		)
 	)
 	{
-		$templateFile = JPATH_TESTING_BASE . "/acceptance.suite.container.yml";
-		$resultFile = JPATH_TESTING_BASE . "/acceptance.suite.yml";
-		$initialSuite = fopen($templateFile, "r") or die("Unable to open file!");
-		$txt = fread($initialSuite, filesize($templateFile));
-		fclose($initialSuite);
-
-		$finalSuite = fopen($resultFile, "w") or die("Unable to open file!");
-		$txt = str_replace("###", $opts['server'], $txt);
-		fwrite($finalSuite, $txt);
-		fclose($finalSuite);
-
 		$this->runCodeceptionSuite(
 			$opts['suite'],
 			$opts['test'],
 			$opts['debug'],
-			$opts['env']
+			$opts['env'],
+			$opts['config']
 		);
 	}
 

--- a/src/RoboFile/ClientContainer.php
+++ b/src/RoboFile/ClientContainer.php
@@ -66,7 +66,6 @@ trait ClientContainer
 			'debug' => false,
 			'suite' => 'acceptance',
 			'test' => 'install',
-			'server' => 'php',
 			'config' => ''
 		)
 	)

--- a/src/RoboFile/RoboFileBase.php
+++ b/src/RoboFile/RoboFileBase.php
@@ -248,6 +248,7 @@ abstract class RoboFileBase extends \Robo\Tasks implements RoboFileInterface
 	 * @param   string  $test   Codeception test to run
 	 * @param   bool    $debug  Execute codeception with debug options
 	 * @param   string  $env    Set a specific environment to get configuration from
+	 * @param   string  $config Special configuration
 	 *
 	 * @return  void
 	 *
@@ -258,7 +259,8 @@ abstract class RoboFileBase extends \Robo\Tasks implements RoboFileInterface
 		$codeceptionTask = $this->taskCodecept()
 			->arg('--fail-fast');
 
-		if(!empty($config)){
+		if (!empty($config))
+		{
 			$codeceptionTask->rawArg($config);
 		}
 

--- a/src/RoboFile/RoboFileBase.php
+++ b/src/RoboFile/RoboFileBase.php
@@ -253,10 +253,14 @@ abstract class RoboFileBase extends \Robo\Tasks implements RoboFileInterface
 	 *
 	 * @since   __DEPLOY_VERSION__
 	 */
-	public function runCodeceptionSuite($suite, $test, $debug = false, $env = '')
+	public function runCodeceptionSuite($suite, $test, $debug = false, $env = '', $config = '')
 	{
 		$codeceptionTask = $this->taskCodecept()
 			->arg('--fail-fast');
+
+		if(!empty($config)){
+			$codeceptionTask->rawArg($config);
+		}
 
 		if ($debug)
 		{


### PR DESCRIPTION
acceptance suite is not reused anymore, instead, the extension should have a separate environment defined for each server.
in order to save the output screenshots in seperate folders and to avoid ovverides, the config option it is used. In case no config is passed, the usual codeception.yml is used. 